### PR TITLE
Fixes #6: add hostname option to Augment

### DIFF
--- a/barf.go
+++ b/barf.go
@@ -1,6 +1,4 @@
-/*
-	package barf
-
+/* package barf
 Basically, A Remarkable Framework!
 */
 package barf

--- a/barf.go
+++ b/barf.go
@@ -1,4 +1,6 @@
-/* package barf
+/*
+	package barf
+
 Basically, A Remarkable Framework!
 */
 package barf
@@ -49,7 +51,7 @@ func createServer(a typing.Augment) error {
 
 	// create server
 	server.HTTP = &http.Server{
-		Addr:              server.Augment.Port,
+		Addr:              fmt.Sprintf("%s:%s", server.Augment.Host, server.Augment.Port),
 		ReadTimeout:       time.Duration(server.Augment.ReadTimeout) * time.Second,
 		WriteTimeout:      time.Duration(server.Augment.WriteTimeout) * time.Second,
 		MaxHeaderBytes:    server.Augment.MaxHeaderBytes,
@@ -80,6 +82,7 @@ func Stark(augmentation ...typing.Augment) error {
 		ReadHeaderTimeout: constant.ReadTimeout,
 		WriteTimeout:      constant.WriteTimeout,
 		ShutdownTimeout:   constant.ShutdownTimeout,
+		Host:              constant.Host,
 		Port:              constant.Port,
 		Logging:           &constant.Logging,
 		Recovery:          &constant.Recovery,
@@ -107,8 +110,11 @@ func Stark(augmentation ...typing.Augment) error {
 		if aug.WriteTimeout != 0 {
 			augu.WriteTimeout = aug.WriteTimeout
 		}
+		if aug.Host != "" {
+			augu.Host = aug.Host
+		}
 		if aug.Port != "" {
-			augu.Port = fmt.Sprintf(":%s", aug.Port)
+			augu.Port = aug.Port
 		}
 		if aug.ReadHeaderTimeout != 0 {
 			augu.ReadHeaderTimeout = aug.ReadHeaderTimeout
@@ -147,7 +153,7 @@ func Beck() error {
 		shutdown()
 	}()
 	// start server
-	logger.Info(fmt.Sprintf("BARF server started at http://localhost%s", server.Augment.Port))
+	logger.Info(fmt.Sprintf("BARF server started at http://%s:%s", server.Augment.Host, server.Augment.Port))
 	if err := server.HTTP.ListenAndServe(); err != nil {
 		server.Beckoned = nil
 		return err

--- a/constant/barf.go
+++ b/constant/barf.go
@@ -25,8 +25,11 @@ const (
 	// request line. It does not limit the size of the request body.
 	MaxHeaderBytes = 1 << 20 // 1 MB
 
+	// Host is the host for the server to listen on
+	Host = ""
+
 	// Port is the port for the server to listen on
-	Port = ":21186"
+	Port = "21186"
 
 	// EnvPath is the path to the environment variables file
 	EnvPath = ".env"

--- a/constant/barf.go
+++ b/constant/barf.go
@@ -26,7 +26,7 @@ const (
 	MaxHeaderBytes = 1 << 20 // 1 MB
 
 	// Host is the host for the server to listen on
-	Host = ""
+	Host = "127.0.0.1"
 
 	// Port is the port for the server to listen on
 	Port = "21186"

--- a/typing/barf.go
+++ b/typing/barf.go
@@ -22,6 +22,8 @@ type Augment struct {
 	// ShutdownTimeout is the time in seconds to wait for the server to shutdown gracefully
 	// default is 5 seconds
 	ShutdownTimeout int
+	// Host is the host for the server to listen on
+	Host string
 	// Port is the port for the server to listen on
 	Port string
 	// ReadHeaderTimeout is the amount of time allowed to read


### PR DESCRIPTION
I added an option `Host` to `Augment` because otherwise, it'd always listen on `*` (not `localhost` as in the log message).