### PR TITLE
feat: implements support for https

### DIFF
--- a/barf.go
+++ b/barf.go
@@ -163,18 +163,17 @@ func Beck() error {
 	// start server with https enabled
 	if server.Augment.UseHTTPS {
 		logger.Info(fmt.Sprintf("BARF server started at https://%s:%s", server.Augment.Host, server.Augment.Port))
-		err := server.HTTP.ListenAndServeTLS(server.Augment.SSLCertFile, server.Augment.SSLKeyFile)
-		if err != nil {
+		if err := server.HTTP.ListenAndServeTLS(server.Augment.SSLCertFile, server.Augment.SSLKeyFile); err != nil {
 			server.Beckoned = nil
 			return err
 		}
-	}
-
-	// start server
-	logger.Info(fmt.Sprintf("BARF server started at http://%s:%s", server.Augment.Host, server.Augment.Port))
-	if err := server.HTTP.ListenAndServe(); err != nil {
-		server.Beckoned = nil
-		return err
+	} else {
+		// start server
+		logger.Info(fmt.Sprintf("BARF server started at http://%s:%s", server.Augment.Host, server.Augment.Port))
+		if err := server.HTTP.ListenAndServe(); err != nil {
+			server.Beckoned = nil
+			return err
+		}
 	}
 	return nil
 }

--- a/constant/barf.go
+++ b/constant/barf.go
@@ -33,6 +33,9 @@ const (
 
 	// EnvPath is the path to the environment variables file
 	EnvPath = ".env"
+
+	// UseHTTPS enables barf use https by default. (Default value is false)
+	UseHTTPS = false
 )
 
 var (

--- a/constant/barf.go
+++ b/constant/barf.go
@@ -34,7 +34,7 @@ const (
 	// EnvPath is the path to the environment variables file
 	EnvPath = ".env"
 
-	// UseHTTPS enables barf use https by default. (Default value is false)
+	// UseHTTPS enables barf to use https by default.
 	UseHTTPS = false
 )
 

--- a/typing/barf.go
+++ b/typing/barf.go
@@ -42,12 +42,13 @@ type Augment struct {
 	Recovery *bool
 	// CORS is the configuration for Cross-Origin Resource Sharing
 	CORS *CORS
-	// UseHTTPS enable barf expose an https instance of itself.
-	// This option also requires both SSLCertfile & SSLKeyFile to be present.
+	// UseHTTPS specifies that all barf connections listen on the TCP network address for inbound HTTPS requests.
 	UseHTTPS bool
-	// SSLCertFile requires for https configuration
+	// SSLCertFile is the path to the certificate file.
+	//
+	// If the certificate is signed by a certificate authority, the SSLCertfFile should be the concatenation of the server's certificate, any intermediates, and the CA's certificate.
 	SSLCertFile string
-	// SSLKeyFile required for https configuration
+	// SSLKeyFile is the path to the private key of the certificate in use.
 	SSLKeyFile string
 }
 

--- a/typing/barf.go
+++ b/typing/barf.go
@@ -42,6 +42,13 @@ type Augment struct {
 	Recovery *bool
 	// CORS is the configuration for Cross-Origin Resource Sharing
 	CORS *CORS
+	// UseHTTPS enable barf expose an https instance of itself.
+	// This option also requires both SSLCertfile & SSLKeyFile to be present.
+	UseHTTPS bool
+	// SSLCertFile requires for https configuration
+	SSLCertFile string
+	// SSLKeyFile required for https configuration
+	SSLKeyFile string
 }
 
 // CORS holds configuration for Cross-Origin Resource Sharing


### PR DESCRIPTION
This PR implements support for https using the native `http.ListenAndServeTLS()` method. Fixes #4 