### PR TITLE
feat: implement route specific middlewares

### DIFF
--- a/example/middleware/main.go
+++ b/example/middleware/main.go
@@ -94,6 +94,16 @@ func main() {
 		})
 	}, middleware)
 
+	// single route middlewares on subroutes route
+	s := barf.RetroFrame("/app")
+	s.Get("/dashboard", func(w http.ResponseWriter, r *http.Request) {
+		barf.Response(w).Status(http.StatusOK).JSON(barf.Res{
+			Status:  true,
+			Data:    nil,
+			Message: "This also works on subroutes routes",
+		})
+	}, middleware)
+
 	// start server - create & start server
 	if err := barf.Beck(); err != nil {
 		barf.Logger().Error(err.Error())

--- a/example/middleware/main.go
+++ b/example/middleware/main.go
@@ -77,6 +77,23 @@ func main() {
 		})
 	})
 
+	// single route middleware
+	middleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			barf.Logger().Info("single route before 3")
+			next.ServeHTTP(w, r)
+			barf.Logger().Info("single route after 3")
+		})
+	}
+
+	barf.Get("/dashboard/settings", func(w http.ResponseWriter, r *http.Request) {
+		barf.Response(w).Status(http.StatusOK).JSON(barf.Res{
+			Status:  true,
+			Data:    nil,
+			Message: "Dashboard settings",
+		})
+	}, middleware)
+
 	// start server - create & start server
 	if err := barf.Beck(); err != nil {
 		barf.Logger().Error(err.Error())

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -8,13 +8,6 @@ import (
 )
 
 func main() {
-	middleware1 := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			barf.Logger().Info("route specific works before")
-			next.ServeHTTP(w, r)
-			barf.Logger().Info("route specific works after")
-		})
-	}
 	// barf tries to be as unobtrusive as possible, so your route handlers still
 	// inherit the standard http.ResponseWriter and *http.Request parameters
 	barf.Get("/", func(w http.ResponseWriter, r *http.Request) {
@@ -23,7 +16,7 @@ func main() {
 			Data:    nil,
 			Message: "Hello World",
 		})
-	}, middleware1)
+	})
 
 	// create & start server
 	if err := barf.Beck(); err != nil {

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -8,7 +8,13 @@ import (
 )
 
 func main() {
-
+	middleware1 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			barf.Logger().Info("route specific works before")
+			next.ServeHTTP(w, r)
+			barf.Logger().Info("route specific works after")
+		})
+	}
 	// barf tries to be as unobtrusive as possible, so your route handlers still
 	// inherit the standard http.ResponseWriter and *http.Request parameters
 	barf.Get("/", func(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +23,7 @@ func main() {
 			Data:    nil,
 			Message: "Hello World",
 		})
-	})
+	}, middleware1)
 
 	// create & start server
 	if err := barf.Beck(); err != nil {

--- a/router/any.go
+++ b/router/any.go
@@ -1,14 +1,19 @@
 package router
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/opensaucerer/barf/typing"
+)
 
 // Any registers a route with all HTTP method
-func Any(path string, handler func(http.ResponseWriter, *http.Request)) {
+func Any(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
 	for _, method := range methods {
 		route := &Route{
 			Path:    path,
 			Method:  method,
 			Handler: handler,
+			stack:   m,
 		}
 		route.Register()
 	}

--- a/router/any.go
+++ b/router/any.go
@@ -20,12 +20,13 @@ func Any(path string, handler func(http.ResponseWriter, *http.Request), m ...typ
 }
 
 // fany registers a route with all HTTP method and sets the RetroFrame flag
-func fany(path string, handler func(http.ResponseWriter, *http.Request), entry string) {
+func fany(path string, handler func(http.ResponseWriter, *http.Request), entry string, m ...typing.Middleware) {
 	for _, method := range methods {
 		route := &Route{
 			Path:    path,
 			Method:  method,
 			Handler: handler,
+			stack:   m,
 		}
 		route.Register()
 	}

--- a/router/delete.go
+++ b/router/delete.go
@@ -18,13 +18,14 @@ func Delete(path string, handler func(http.ResponseWriter, *http.Request), m ...
 }
 
 // fdelete registers a route with the DELETE HTTP method and sets the RetroFrame flag
-func fdelete(path string, handler func(http.ResponseWriter, *http.Request), entry string) {
+func fdelete(path string, handler func(http.ResponseWriter, *http.Request), entry string, m ...typing.Middleware) {
 	route := &Route{
 		Path:            path,
 		Method:          delete,
 		Handler:         handler,
 		RetroFrame:      true,
 		RetroFrameEntry: entry,
+		stack:           m,
 	}
 	route.Register()
 }

--- a/router/delete.go
+++ b/router/delete.go
@@ -1,13 +1,18 @@
 package router
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/opensaucerer/barf/typing"
+)
 
 // Delete registers a route with the DELETE HTTP method
-func Delete(path string, handler func(http.ResponseWriter, *http.Request)) {
+func Delete(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
 	route := &Route{
 		Path:    path,
 		Method:  delete,
 		Handler: handler,
+		stack:   m,
 	}
 	route.Register()
 }

--- a/router/get.go
+++ b/router/get.go
@@ -18,13 +18,14 @@ func Get(path string, handler func(http.ResponseWriter, *http.Request), m ...typ
 }
 
 // fget registers a route with the GET HTTP method and sets the RetroFrame flag
-func fget(path string, handler func(http.ResponseWriter, *http.Request), entry string) {
+func fget(path string, handler func(http.ResponseWriter, *http.Request), entry string, m ...typing.Middleware) {
 	route := &Route{
 		Path:            path,
 		Method:          get,
 		Handler:         handler,
 		RetroFrame:      true,
 		RetroFrameEntry: entry,
+		stack:           m,
 	}
 	route.Register()
 }

--- a/router/get.go
+++ b/router/get.go
@@ -1,13 +1,18 @@
 package router
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/opensaucerer/barf/typing"
+)
 
 // Get registers a route with the GET HTTP method
-func Get(path string, handler func(http.ResponseWriter, *http.Request)) {
+func Get(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
 	route := &Route{
 		Path:    path,
 		Method:  get,
 		Handler: handler,
+		stack:   m,
 	}
 	route.Register()
 }

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -42,6 +42,13 @@ func Router(respond func(w http.ResponseWriter, status bool, statusCode int, mes
 					}
 				}
 
+				// call route specific middleware(s)
+				if len(route.stack) > 0 {
+					for i := range route.stack {
+						sh = route.stack[len(route.stack)-1-i](sh)
+					}
+				}
+
 				// call route handler
 				route.Handler(w, r.WithContext(ctx))
 			}

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -43,10 +43,8 @@ func Router(respond func(w http.ResponseWriter, status bool, statusCode int, mes
 				}
 
 				// call route specific middleware(s)
-				if len(route.stack) > 0 {
-					for i := range route.stack {
-						sh = route.stack[len(route.stack)-1-i](sh)
-					}
+				for i := range route.stack {
+					sh = route.stack[len(route.stack)-1-i](sh)
 				}
 
 				// call route handler

--- a/router/patch.go
+++ b/router/patch.go
@@ -1,13 +1,18 @@
 package router
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/opensaucerer/barf/typing"
+)
 
 // Patch registers a route with the PATCH HTTP method
-func Patch(path string, handler func(http.ResponseWriter, *http.Request)) {
+func Patch(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
 	route := &Route{
 		Path:    path,
 		Method:  patch,
 		Handler: handler,
+		stack:   m,
 	}
 	route.Register()
 }

--- a/router/patch.go
+++ b/router/patch.go
@@ -18,13 +18,14 @@ func Patch(path string, handler func(http.ResponseWriter, *http.Request), m ...t
 }
 
 // fpatch registers a route with the PATCH HTTP method and sets the RetroFrame flag
-func fpatch(path string, handler func(http.ResponseWriter, *http.Request), entry string) {
+func fpatch(path string, handler func(http.ResponseWriter, *http.Request), entry string, m ...typing.Middleware) {
 	route := &Route{
 		Path:            path,
 		Method:          patch,
 		Handler:         handler,
 		RetroFrame:      true,
 		RetroFrameEntry: entry,
+		stack:           m,
 	}
 	route.Register()
 }

--- a/router/post.go
+++ b/router/post.go
@@ -1,13 +1,18 @@
 package router
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/opensaucerer/barf/typing"
+)
 
 // Post registers a route with the POST HTTP method
-func Post(path string, handler func(http.ResponseWriter, *http.Request)) {
+func Post(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
 	route := &Route{
 		Path:    path,
 		Method:  post,
 		Handler: handler,
+		stack:   m,
 	}
 	route.Register()
 }

--- a/router/post.go
+++ b/router/post.go
@@ -18,13 +18,14 @@ func Post(path string, handler func(http.ResponseWriter, *http.Request), m ...ty
 }
 
 // fpost registers a route with the POST HTTP method and sets the RetroFrame flag
-func fpost(path string, handler func(http.ResponseWriter, *http.Request), entry string) {
+func fpost(path string, handler func(http.ResponseWriter, *http.Request), entry string, m ...typing.Middleware) {
 	route := &Route{
 		Path:            path,
 		Method:          post,
 		Handler:         handler,
 		RetroFrame:      true,
 		RetroFrameEntry: entry,
+		stack:           m,
 	}
 	route.Register()
 }

--- a/router/put.go
+++ b/router/put.go
@@ -18,13 +18,14 @@ func Put(path string, handler func(http.ResponseWriter, *http.Request), m ...typ
 }
 
 // fput registers a route with the PUT HTTP method and sets the RetroFrame flag
-func fput(path string, handler func(http.ResponseWriter, *http.Request), entry string) {
+func fput(path string, handler func(http.ResponseWriter, *http.Request), entry string, m ...typing.Middleware) {
 	route := &Route{
 		Path:            path,
 		Method:          put,
 		Handler:         handler,
 		RetroFrame:      true,
 		RetroFrameEntry: entry,
+		stack:           m,
 	}
 	route.Register()
 }

--- a/router/put.go
+++ b/router/put.go
@@ -1,13 +1,18 @@
 package router
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/opensaucerer/barf/typing"
+)
 
 // Put registers a route with the PUT HTTP method
-func Put(path string, handler func(http.ResponseWriter, *http.Request)) {
+func Put(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
 	route := &Route{
 		Path:    path,
 		Method:  put,
 		Handler: handler,
+		stack:   m,
 	}
 	route.Register()
 }

--- a/router/retroframe.go
+++ b/router/retroframe.go
@@ -33,31 +33,31 @@ func (r *SubRoute) RetroFrame(path string) *SubRoute {
 }
 
 // Get registers a route with the GET HTTP method against the path of the RetroFrame router instance.
-func (r *SubRoute) Get(path string, handler func(http.ResponseWriter, *http.Request)) {
-	fget(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key)
+func (r *SubRoute) Get(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
+	fget(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key, m...)
 }
 
 // Post registers a route with the POST HTTP method against the path of the RetroFrame router instance.
-func (r *SubRoute) Post(path string, handler func(http.ResponseWriter, *http.Request)) {
-	fpost(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key)
+func (r *SubRoute) Post(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
+	fpost(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key, m...)
 }
 
 // Put registers a route with the PUT HTTP method against the path of the RetroFrame router instance.
-func (r *SubRoute) Put(path string, handler func(http.ResponseWriter, *http.Request)) {
-	fput(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key)
+func (r *SubRoute) Put(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
+	fput(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key, m...)
 }
 
 // Patch registers a route with the PATCH HTTP method against the path of the RetroFrame router instance.
-func (r *SubRoute) Patch(path string, handler func(http.ResponseWriter, *http.Request)) {
-	fpatch(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key)
+func (r *SubRoute) Patch(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
+	fpatch(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key, m...)
 }
 
 // Delete registers a route with the DELETE HTTP method against the path of the RetroFrame router instance.
-func (r *SubRoute) Delete(path string, handler func(http.ResponseWriter, *http.Request)) {
-	fdelete(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key)
+func (r *SubRoute) Delete(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
+	fdelete(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key, m...)
 }
 
 // Any registers a route with the all HTTP method against the path of the RetroFrame router instance.
-func (r *SubRoute) Any(path string, handler func(http.ResponseWriter, *http.Request)) {
-	fany(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key)
+func (r *SubRoute) Any(path string, handler func(http.ResponseWriter, *http.Request), m ...typing.Middleware) {
+	fany(fmt.Sprintf("/%s/%s", r.entry, regexp.MustCompile("^/+|/+$").ReplaceAllString(path, "")), handler, r.key, m...)
 }

--- a/router/routing.go
+++ b/router/routing.go
@@ -14,6 +14,7 @@ type Route struct {
 	Params          map[string]string
 	RetroFrame      bool   // true for routes registered on a SubRoute
 	RetroFrameEntry string // entry path of the SubRoute
+	stack           []typing.Middleware
 }
 
 type SubRoute struct {


### PR DESCRIPTION
Currently, this idea only applies to `barf.Get()` routes. An implementation example can be found within `example/simple/main.go` file.