### PR TITLE
chore: remove redudant parameter for server augment in createServer function

### DIFF
--- a/barf.go
+++ b/barf.go
@@ -22,7 +22,7 @@ import (
 	"github.com/opensaucerer/barf/typing"
 )
 
-func createServer(a typing.Augment) error {
+func createServer() error {
 
 	// create handler
 	server.Mux = http.NewServeMux()
@@ -137,7 +137,7 @@ func Stark(augmentation ...typing.Augment) error {
 	}
 	// make config global
 	server.Augment = &augu
-	return createServer(augu)
+	return createServer()
 }
 
 // Beck starts the barf server and returns an error, if any. Alternatively, Beck also creates a new barf server with the default config and starts it, only if barf.Stark() was not called before.


### PR DESCRIPTION
This PR removes a redundant parameter in the createServer function.
Since the server.Augment value has been set globally, we no longer need to pass the parameter to the function as the function also uses the global server.Augment value.

This ensures consistency in the use of server.Augment across the package